### PR TITLE
Fix the error on the cron admin page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,6 @@ RUN sed -i -e "s/html/html\/src/g" /etc/apache2/sites-enabled/000-default.conf
 
 # enable apache module rewrite
 RUN a2enmod rewrite
+
+# use default developer config
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"

--- a/src/admin/cron_manage.php
+++ b/src/admin/cron_manage.php
@@ -50,7 +50,7 @@ class AdminCronManage
         }
         $cron_url = substr($db->get_site_setting('classifieds_url'), 0, strpos($db->get_site_setting('classifieds_url'), $db->get_site_setting('classifieds_file_name')));
         $cron_url .= 'cron.php?action=cron&cron_key=' . $cron_key;
-        $cron_command = $product_configuration->path_translated() . '/cron.php --help';
+        $cron_command = GEO_BASE_DIR . 'cron.php --help';
         $html = $menu_loader->getUserMessages() . "
 <div class=\"page_note_error\"><strong>Warning</strong>: Changing settings on this page can have drastic effects if your server
 is not configured correctly.  It is important that you <strong>consult the user manual</strong>, so that you may fully understand what is happening, before changing any settings on this page.</div>


### PR DESCRIPTION
We previously removed `path_translated` since it used the installation path from the license details.  I thought I had updated all the places but missed one spot: this fixes the spot.

Also a minor tweak in the docker setup to make it use the dev version of php.ini from the docker image.