### PR TITLE
Update old copyright notices to say distributed freely under MIT license

### DIFF
--- a/src/admin/templates/index.tpl
+++ b/src/admin/templates/index.tpl
@@ -216,9 +216,8 @@
 							</div>
 							<div id="footer">
 								<div id="footer-inside">
-									<p>Copyright © 2022</p>
-                                    <p>
-                                        Licensed under <a href="https://github.com/geodesicsolutions-community/geocore-community/blob/42e315b06b57a3a42b1352713258866fc691be70/LICENSE" target="_blank">MIT License</a>
+									<p>
+                                        Distributed freely under <a href="https://github.com/geodesicsolutions-community/geocore-community/blob/42e315b06b57a3a42b1352713258866fc691be70/LICENSE" target="_blank">MIT License</a>
                                     </p>
 								</div>
 							</div>

--- a/src/admin/templates/login.tpl
+++ b/src/admin/templates/login.tpl
@@ -118,9 +118,7 @@
 								<a href="https://geodesicsolutions.org/wiki/startup_tutorial_and_checklist/admin_controls/admin_login_change/reset_admin_login_when_loststart/" onclick="window.open(this.href); return false;">Forgot Password?</a>
 							</div>
 						{/if}
-
-
-						<div id="login_copyright">Copyright 2001-2018. All Rights Reserved.</div>
+						<div id="login_copyright">Copyright 2022. All Rights Reserved.</div>
 					</div>
 					<div id="login_bottom"></div>
 				</div>

--- a/src/setup/main.html
+++ b/src/setup/main.html
@@ -40,6 +40,8 @@ jQuery(function () {
 					<ul>
 						<li style="list-style-image: none; list-style: none;">&nbsp;</li>
 						<li><a href="https://geodesicsolutions.org/wiki/" target="_blank">User Manual</a></li>
+                        <li><a href="https://github.com/geodesicsolutions-community/geocore-community/discussions">Community Discussion</a></li>
+                        <li><a href="https://geodesicsolutions.org">Website</a></li>
 					</ul>
 				</div>
 				<div id="login_right">
@@ -48,6 +50,9 @@ jQuery(function () {
 					<div id="login_form_fields">
 					(!MAINBODY!)
 					</div>
+					<div id="login_copyright">
+                        Distributed freely under <a href="https://github.com/geodesicsolutions-community/geocore-community/blob/40dda8b846a236688efcbd87fcfb7fa9280c4255/LICENSE" target="_blank">MIT License</a>
+                    </div>
 				</div>
 				<div style="clear: both;"></div>
 			</div>

--- a/src/setup/steps/layout.php
+++ b/src/setup/steps/layout.php
@@ -40,6 +40,8 @@ jQuery(function () {
                     <ul>
                         <li style="list-style-image: none; list-style: none;">&nbsp;</li>
                         <li><a href="https://geodesicsolutions.com/wiki/" target="_blank">User Manual</a></li>
+                        <li><a href="https://github.com/geodesicsolutions-community/geocore-community/discussions" target="_blank">Community Discussion</a></li>
+                        <li><a href="https://geodesicsolutions.org" target="_blank">Website</a></li>
                     </ul>
                 </div>
                 <div id="login_right">
@@ -47,6 +49,9 @@ jQuery(function () {
                     <h2 id="login_software_type">&nbsp;</h2>
                     <div id="login_form_fields">
                         <?php require($step . '.php'); ?>
+                    </div>
+                    <div id="login_copyright">
+                        Distributed freely under <a href="https://github.com/geodesicsolutions-community/geocore-community/blob/40dda8b846a236688efcbd87fcfb7fa9280c4255/LICENSE" target="_blank">MIT License</a>
                     </div>
                 </div>
                 <div style="clear: both;"></div>

--- a/src/upgrade/templates/index.tpl
+++ b/src/upgrade/templates/index.tpl
@@ -42,8 +42,10 @@ jQuery(function () {
 					<div id="login_left_list"></div>
 					<ul>
 						<li style="list-style-image: none; list-style: none;">&nbsp;</li>
-						<li><a href="versions/changelogs.php" onclick="window.open(this.href); return false;">Changelog</a></li>
+						<li><a href="versions/changelogs.php" target="_blank">Changelog</a></li>
 						<li><a href="https://geodesicsolutions.org/wiki/" target="_blank">User Manual</a></li>
+						<li><a href="https://github.com/geodesicsolutions-community/geocore-community/discussions" target="_blank">Community Discussion</a></li>
+						<li><a href="https://geodesicsolutions.org" target="_blank">Website</a></li>
 					</ul>
 				</div>
 				<div id="login_right">
@@ -53,7 +55,9 @@ jQuery(function () {
 					{if $body_tpl}{include file=$body_tpl}{/if}
 {$body}
 					</div>
-					<div id="login_copyright">Copyright 2001-2018. <a class="login_link" href="http://geodesicsolutions.com" onclick="window.open(this.href); return false;">Geodesic Solutions, LLC.</a><br />All Rights Reserved.</div>
+					<div id="login_copyright">
+                        Distributed freely under <a href="https://github.com/geodesicsolutions-community/geocore-community/blob/40dda8b846a236688efcbd87fcfb7fa9280c4255/LICENSE" target="_blank">MIT License</a>
+                    </div>
 				</div>
 				<div style="clear: both;"></div>
 			</div>


### PR DESCRIPTION
In admin footer, setup, and upgrade, this removes the copyright and replaces it with text like:

> Distributed freely under MIT License

With it linking directly to the license in github.

In the admin login, since that is technically viewable by public, just made it say `copyright 2022`.