### PR TITLE
Fix SQL query error in storefront cron, trying to pass a query param …

### DIFF
--- a/src/addons/storefront/cron/expire_storefront_subscriptions.php
+++ b/src/addons/storefront/cron/expire_storefront_subscriptions.php
@@ -42,7 +42,7 @@ if (geoPC::is_ent()) {
 $this->log('Deleting all storefront subscriptions that should be expired already.', __line__);
 $sql = "DELETE FROM `geodesic_addon_storefront_subscriptions`
 	WHERE `expiration` < " . (geoUtil::time() - $grace) . " AND `onhold_start_time` = 0";
-$expire_subscriptions_results = $this->db->Execute($sql, array((int)$planRow['price_plan_id']));
+$expire_subscriptions_results = $this->db->Execute($sql);
 
 if (!$expire_subscriptions_results) {
     $this->log('Error running query, cron job failed.  query: ' . $sql . ' - Error Msg: ' . $this->db->ErrorMsg(), __line__);


### PR DESCRIPTION
…to a query with no params

It may be worth noting, this fixes a long-standing "invisible" bug that has been in there for many years.

Perhaps previous versions of ADODB hid the error and executed the query anyways.  Or perhaps no one ever noticed.  Either way, this fixes it now.

Fixes #49