### PR TITLE
Add PHPStan tool to help identify bugs, and fix a few of them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "wiki": "https://geodesicsolutions.org/wiki"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-gd": "*",
         "ext-mysqli": "*",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "wiki": "https://geodesicsolutions.org/wiki"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.0",
         "ext-curl": "*",
         "ext-gd": "*",
         "ext-mysqli": "*",
@@ -21,7 +21,8 @@
         "vendor-dir": "src/vendor"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.6"
+        "squizlabs/php_codesniffer": "^3.6",
+        "phpstan/phpstan": "^1.4"
     },
     "scripts": {
         "post-install-cmd": [
@@ -32,6 +33,7 @@
         ],
         "cs-check": "phpcs -s --standard=./contrib/phpcs-ruleset.xml",
         "cs-fix": "phpcbf --colors --standard=./contrib/phpcs-ruleset.xml",
+        "stan": "php -d memory_limit=2G src/vendor/bin/phpstan analyse src",
         "build-release": "bash contrib/build-release"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45f7f817864610f316d5fff54e7185ac",
+    "content-hash": "9a3b713c9966477707aa4cf58eb3757e",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -130,6 +130,70 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8a7761f1c520e0dad6e04d862fdc697445457cfe",
+                "reference": "8a7761f1c520e0dad6e04d862fdc697445457cfe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-06T12:56:13+00:00"
+        },
         {
             "name": "squizlabs/php_codesniffer",
             "version": "3.6.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+parameters:
+    # Let's get level 0 working then we can improve...
+    level: 0
+    # We want to make sure it is compatible with PHP 7.1
+    phpVersion: 70100
+    paths:
+        - src
+    excludePaths:
+        - src/vendor
+        - src/templates_c
+        # ignore upgrade for now, to focus on main codeset
+        - src/upgrade
+        - src/setup
+        - src/pre_setup

--- a/src/classes/browse_vote.php
+++ b/src/classes/browse_vote.php
@@ -11,7 +11,7 @@ class browse_vote extends geoSite
 
 //########################################################################
 
-    function Browse_vote($db = 0, $classified_user_id, $language_id, $category_id = 0, $page = 0, $classified_id = 0, $filter_id = 0, $product_configuration = 0)
+    function __construct($db = 0, $classified_user_id, $language_id, $category_id = 0, $page = 0, $classified_id = 0, $filter_id = 0, $product_configuration = 0)
     {
         if ($category_id) {
             $this->site_category = (int)$category_id;
@@ -213,7 +213,7 @@ class browse_vote extends geoSite
         $view->listing = $listing->toArray();
 
         $sql = "select * from " . geoTables::voting_table . " where classified_id = " . $classified_id . "
-		     order by date_entered desc 
+		     order by date_entered desc
 		     limit " . (($this->page_result - 1) * $db->get_site_setting('number_of_vote_comments_to_display')) . "," . $db->get_site_setting('number_of_vote_comments_to_display');
         $result = $db->Execute($sql);
         if ((!$result)) {

--- a/src/classes/user_management_invited_list_buyers.php
+++ b/src/classes/user_management_invited_list_buyers.php
@@ -2,18 +2,18 @@
 
 class Invited_list_buyers extends geoSite
 {
-
-    var $item_id;
-    var $user_id;
-    var $feedback_messages;
-    var $user_data;
-    var $search_error_message;
+    protected $users;
+    public $item_id;
+    public $user_id;
+    public $feedback_messages;
+    public $user_data;
+    public $search_error_message;
 
     // Debug variables
-    var $filename = "user_management_invited_list_buyers.php";
-    var $function_name;
+    public $filename = "user_management_invited_list_buyers.php";
+    public $function_name;
 
-    var $debug_invited = 0;
+    public $debug_invited = 0;
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -148,9 +148,9 @@ class Invited_list_buyers extends geoSite
                         $this->site_error();
                         return false;
                     } elseif ($check_result->RecordCount() == 0) {
-                        $this->sql_query = "insert into " . $this->invitedlist_table . " 
+                        $this->sql_query = "insert into " . $this->invitedlist_table . "
 							(seller_id,user_id)
-							values 
+							values
 							(" . $this->user_id . ", " . $users['user_id'][$i] . ")  ";
                         $insert_result = $db->Execute($this->sql_query);
                         if (!$insert_result) {

--- a/src/index.php
+++ b/src/index.php
@@ -1093,25 +1093,6 @@ switch ($_REQUEST["a"]) {
         }
         break;
 
-    case 22:
-        //extra page
-        $site = new geoSite();
-        if (($_REQUEST["b"]) && (is_numeric($_REQUEST["b"]))) {
-            if (!$site->extra_page($db, $_REQUEST["b"])) {
-                include_once(CLASSES_DIR . "browse_ads.php");
-                $browse = new Browse_ads($user_id, $language_id, 0, 0);
-                if (!$browse->main()) {
-                    $browse->browse_error();
-                }
-            }
-        } else {
-            include_once(CLASSES_DIR . "browse_ads.php");
-            $browse = new Browse_ads($user_id, $language_id, 0, 0);
-            if (!$browse->main()) {
-                $browse->browse_error();
-            }
-        }
-        break;
     case 25:
         //display sellers within a category
         //b will contain the category id

--- a/src/index.php
+++ b/src/index.php
@@ -149,9 +149,6 @@ switch ($_REQUEST["a"]) {
 
     case 2:
         //display a classified
-        if (isset($get_execution_time) && $get_execution_time) {
-            get_end_time($starttime);
-        }
         include_once(CLASSES_DIR . "browse_display_ad.php");
         if (isset($_REQUEST['amp;b']) && !isset($_REQUEST['b'])) {
             $_REQUEST['b'] = $_REQUEST['amp;b'];
@@ -178,9 +175,6 @@ switch ($_REQUEST["a"]) {
             if (!$browse->main()) {
                 $browse->browse_error();
             }
-        }
-        if ($get_execution_time) {
-            get_end_time($starttime);
         }
         break;
 
@@ -1142,7 +1136,7 @@ switch ($_REQUEST["a"]) {
         if (geoPC::is_ent()) {
             //classified voting
             include_once(CLASSES_DIR . "browse_vote.php");
-            $vote = new Browse_vote($db, $user_id, $language_id, 0, $_REQUEST["page"], $_REQUEST["b"], 0, $product_configuration);
+            $vote = new browse_vote($db, $user_id, $language_id, 0, $_REQUEST["page"], $_REQUEST["b"], 0, $product_configuration);
             if (($_REQUEST["b"]) && (is_numeric($_REQUEST["b"])) && ($_REQUEST["c"]) && (is_array($_REQUEST["c"]))) {
                 //collect the vote and go back to classified id
                 if (!$vote->collect_vote($_REQUEST["b"], $_REQUEST["c"])) {
@@ -1186,7 +1180,7 @@ switch ($_REQUEST["a"]) {
         if (geoPC::is_ent()) {
             //classified vote browsing
             include_once(CLASSES_DIR . "browse_vote.php");
-            $vote = new Browse_vote($db, $user_id, $language_id, 0, $_REQUEST["page"], $_REQUEST["b"], 0, $product_configuration);
+            $vote = new browse_vote($db, $user_id, $language_id, 0, $_REQUEST["page"], $_REQUEST["b"], 0, $product_configuration);
             if (($_REQUEST["b"]) && (is_numeric($_REQUEST["b"]))) {
                 if ($_REQUEST['d'] && is_numeric($_REQUEST['d'])) {
                     //delete this vote, then return to the browse votes page


### PR DESCRIPTION
You can now run `composer phpstan` in the project.  I have the settings dialed back as "lax" as they go, and still it is finding 2k potential problems.

I went through and fixed a small hand-full of them:
* browse vote class name used
* Remove calls to a function that did not exist in a less used (or maybe never used) section of code
* Removed a=22 section of the index, it appears to be a "dead index" that was either replaced, or started but not finished or something.  It was for extra pages it looks like but the working extra pages on is a=26

Note: I only fixed the above, there are too many to fix all at once.  Like with the `cs-check` we'll fix them in small batches to make it more manageable.