### PR TITLE
Add a new composer script to do all the scans and output to files to …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ src/addons/exporter/exports/
 
 # Built zip files
 build/
+
+# Scan error files
+stan.txt
+cs-check.txt

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "cs-check": "phpcs -s --standard=./contrib/phpcs-ruleset.xml",
         "cs-fix": "phpcbf --colors --standard=./contrib/phpcs-ruleset.xml",
         "stan": "php -d memory_limit=2G src/vendor/bin/phpstan analyse src",
+        "scan-all": "bash contrib/scan-all",
         "build-release": "bash contrib/build-release"
     }
 }

--- a/contrib/scan-all
+++ b/contrib/scan-all
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This runs the checkers and outputs to files to make it easier to clean things up
+
+echo
+echo Starting phpcs and dumping results in cs-check.txt
+echo --------------------------------------------------
+echo
+
+composer cs-check > cs-check.txt
+
+echo
+echo Done!
+echo -----
+echo
+echo Starting phpstan and dumping results in stan.txt
+echo ------------------------------------------------
+echo
+
+composer stan > stan.txt
+
+echo
+echo Done!
+echo -----
+echo
+echo Look in the files for complete scan results:
+echo
+echo ' * cs-check.txt'
+echo ' * stan.txt'
+echo


### PR DESCRIPTION
…make it easier to fix things

It adds the command:

```
composer scan-all
```

That will generate 2 files:
* cs-check.txt
* stan.txt

Note that the filename matches the composer script used to generate it.

It also adds those file to gitignore.