### PR TITLE
Change the upload_max_filesize to 64M on the docker php.ini settings

### DIFF
--- a/contrib/docker/upload-limit.ini
+++ b/contrib/docker/upload-limit.ini
@@ -1,0 +1,1 @@
+upload_max_filesize=64M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - .:/var/www/html/
       - ./contrib/docker/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./contrib/docker/upload-limit.ini:/usr/local/etc/php/conf.d/docker-upload-limit.ini
 
   web-php8:
     build:
@@ -24,6 +25,7 @@ services:
     volumes:
       - .:/var/www/html/
       - ./contrib/docker/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./contrib/docker/upload-limit.ini:/usr/local/etc/php/conf.d/docker-upload-limit.ini
 
   db:
     image: mariadb


### PR DESCRIPTION
Note that this only affects docker installations.